### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "julia"
+run = "indludet(\"bot.jl\")"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Shiro-Bot
+[![Run on Repl.it](https://repl.it/badge/github/3Nya3/Shiro-Bot)](https://repl.it/github/3Nya3/Shiro-Bot)
 A little sister bot who always has your back!  
 
 Shiro, from No Game No Life


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).